### PR TITLE
Roll back cim16 import

### DIFF
--- a/PyCIM/RDFXMLReader.py
+++ b/PyCIM/RDFXMLReader.py
@@ -263,15 +263,17 @@ def get_cim_ns(namespaces):
         ns = ''
         logger.error('No CIM namespace defined in input file.')
 
+    CIM16nsURI = 'http://iec.ch/TC57/2013/CIM-schema-cim16'
+
     nsuri = ns
 
-    import CIM14, CIM15, CIM16
+    import CIM14, CIM15
     if ns == CIM14.nsURI:
         ns = 'CIM14'
     elif ns == CIM15.nsURI:
         ns = 'CIM15'
-    elif ns == CIM16.nsURI:
-        ns  = 'CIM16'
+    elif ns == CIM16nsURI:
+        ns  = 'CIM15'
     else:
         ns = 'CIM15'
         logger.warn('Could not detect CIM version. Using %s.' % ns)

--- a/PyCIM/RDFXMLReader.py
+++ b/PyCIM/RDFXMLReader.py
@@ -236,6 +236,11 @@ def xmlns(source):
             namespaces[prefix] = ns
         elif event == "end":
             break
+
+    # Reset stream
+    if hasattr(source, "seek"):
+        source.seek(0)
+
     return namespaces
 
 


### PR DESCRIPTION
This rolls back a code change that was importing CIM16. Since we don't have a CIM16 package in the project yet, this reverts back to the previous behaviour, where CIM15 is used instead. Fixes #11 

This pull request also includes a fix in RDFXMLReader that was causing a test to fail. The test uses StringIO as a file handle but the code had a bug that prevented file handles from working.