### PR TITLE
Rename README to README.rst and add travis badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://travis-ci.org/rwl/PyCIM.svg?branch=master
+    :target: https://travis-ci.org/rwl/PyCIM
 ============
 Introduction
 ============


### PR DESCRIPTION
The .rst tells GitHub how to render the README, and the badge is from travis. It shows whether the master branch is currently passing or not.