### PR TITLE
Stop using dict as default value for func arg

### DIFF
--- a/PyCIM/RDFXMLReader.py
+++ b/PyCIM/RDFXMLReader.py
@@ -28,7 +28,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def cimread(source, packageMap=None, nsURI=None, start_dict={}):
+def cimread(source, packageMap=None, nsURI=None, start_dict=None):
     """ CIM RDF/XML parser.
 
     @type source: File-like object or a path to a file.
@@ -55,7 +55,7 @@ def cimread(source, packageMap=None, nsURI=None, start_dict={}):
     logger_errors_grouped = {}
 
     # A map of uuids to CIM objects to be returned.
-    d = start_dict
+    d = start_dict if start_dict is not None else {}
 
     # Obtain the namespaces from the input file
     namespaces = xmlns(source)

--- a/PyCIM/Test/RDFXMLReaderTest.py
+++ b/PyCIM/Test/RDFXMLReaderTest.py
@@ -19,6 +19,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 
+import io
 import unittest
 
 from os.path import dirname, join
@@ -39,6 +40,10 @@ CONN_FILE = join(dirname(__file__), "Data", "EDF_AIGUE_v9_CONN.xml")
 EQUIP_FILE = join(dirname(__file__), "Data", "EDF_AIGUE_v9_EQUIP.xml")
 GEO_FILE = join(dirname(__file__), "Data", "EDF_AIGUE_v9_GEO.xml")
 
+EMPTY_CIM = u'''<?xml version=\'1.0\'?>
+<rdf:RDF xmlns:cim="http://iec.ch/TC57/2010/CIM-schema-cim15#"
+xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" />'''
+
 
 class RDFXMLReaderTestCase(unittest.TestCase):
     """Test CIM RDF/XML parsing.
@@ -51,6 +56,12 @@ class RDFXMLReaderTestCase(unittest.TestCase):
 
         self.assertEqual(len(d), 5894)
 
+    def test_cim_reads_are_independent(self):
+        cimread(ASSET_FILE, assetMap, nsURICIM15)
+        sio = io.StringIO(EMPTY_CIM)
+        empty_cim_dict = cimread(sio)
+        self.assertEqual(empty_cim_dict, {})
+
     def testProfile(self):
         d = {}
 
@@ -59,7 +70,7 @@ class RDFXMLReaderTestCase(unittest.TestCase):
         d.update(cimread(EQUIP_FILE, equipMap, nsURICIM15))
         d.update(cimread(GEO_FILE, geoMap, nsURICIM15))
 
-        self.assertEqual(len(d), 5894)
+        self.assertEqual(len(d), 5893)
 
     def testGetNamespaces(self):
         ns = RDFXMLReader.xmlns(RDFXML_FILE)


### PR DESCRIPTION
This gets you into trouble in python, because the same reference to the
same actual object gets used every time the function is called. So if
there's a dict there, and you modify it, your modifications will be in
the default value the next time you call the function.

TLDR: Only use immutable types for default values.